### PR TITLE
Add ability to request multiple certificates

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -24,8 +24,9 @@ class TlsProvides(RelationBase):
         cn = conversation.get_remote('common_name')
         sans = conversation.get_remote('sans')
         name = conversation.get_remote('certificate_name')
+        requests = conversation.get_remote('cert_requests')
         # When the relation has all three values set the server.cert.requested.
-        if cn and sans and name:
+        if (cn and sans and name) or requests:
             conversation.set_state('{relation_name}.server.cert.requested')
 
     @hook('{provides:tls-certificates}-relation-{broken,departed}')
@@ -40,6 +41,13 @@ class TlsProvides(RelationBase):
         for conversation in self.conversations():
             # All the clients get the same CA, so send it to them.
             conversation.set_remote(data={'ca': certificate_authority})
+
+    def set_chain(self, chain):
+        '''Set the chain on all the conversations in the relation data.'''
+        # Iterate over all conversations of this type.
+        for conversation in self.conversations():
+            # All the clients get the same chain, so send it to them.
+            conversation.set_remote(data={'chain': chain})
 
     def set_client_cert(self, cert, key):
         '''Set the client cert and key on the relation data.'''
@@ -66,6 +74,38 @@ class TlsProvides(RelationBase):
         # Remove the server.cert.requested state as it is no longer needed.
         conversation.remove_state('{relation_name}.server.cert.requested')
 
+    def set_server_multicerts(self, scope):
+        conversation = self.conversation(scope)
+        multi_certs = conversation.get_local('multi_certs')
+        conversation.set_remote(
+            'processed_requests',
+            json.dumps(multi_certs, sort_keys=True))
+        conversation.remove_state('{relation_name}.server.cert.requested')
+
+    def add_server_cert(self, scope, cn, cert, key):
+        '''
+            'client_0': {
+                'admin': {
+                    'cert': cert
+                    'key': key}}
+        '''
+        conversation = self.conversation(scope)
+        # The scope is the unit name, replace the slash with underscore.
+        name = scope.replace('/', '_')
+        multi_certs = conversation.get_local('multi_certs')
+        if multi_certs:
+            multi_certs[cn] = {
+                'cert': cert,
+                'key': key}
+
+        else:
+            multi_certs = {
+                cn: {
+                    'cert': cert,
+                    'key': key}}
+
+        conversation.set_local('multi_certs', multi_certs)
+
     def get_server_requests(self):
         '''One provider can have many requests to generate server certificates.
         Return a map of all server request objects indexed by the scope
@@ -75,8 +115,13 @@ class TlsProvides(RelationBase):
             scope = conversation.scope
             request = {}
             request['common_name'] = conversation.get_remote('common_name')
-            request['sans'] = json.loads(conversation.get_remote('sans'))
+            sans = conversation.get_remote('sans')
+            if sans:
+                request['sans'] = json.loads(sans)
             request['certificate_name'] = conversation.get_remote('certificate_name')  # noqa
+            cert_requests = conversation.get_remote('cert_requests')
+            if cert_requests:
+                request['cert_requests'] = json.loads(cert_requests)
             # Create a map indexed by scope.
             request_map[scope] = request
         return request_map

--- a/provides.py
+++ b/provides.py
@@ -75,10 +75,12 @@ class TlsProvides(RelationBase):
         conversation.remove_state('{relation_name}.server.cert.requested')
 
     def set_server_multicerts(self, scope):
+        # The scope is the unit name, replace the slash with underscore.
+        name = scope.replace('/', '_')
         conversation = self.conversation(scope)
         multi_certs = conversation.get_local('multi_certs')
         conversation.set_remote(
-            'processed_requests',
+            '{}.processed_requests'.format(name),
             json.dumps(multi_certs, sort_keys=True))
         conversation.remove_state('{relation_name}.server.cert.requested')
 
@@ -90,8 +92,6 @@ class TlsProvides(RelationBase):
                     'key': key}}
         '''
         conversation = self.conversation(scope)
-        # The scope is the unit name, replace the slash with underscore.
-        name = scope.replace('/', '_')
         multi_certs = conversation.get_local('multi_certs')
         if multi_certs:
             multi_certs[cn] = {

--- a/requires.py
+++ b/requires.py
@@ -35,7 +35,7 @@ class TlsRequires(RelationBase):
         # Prefix the key with the name so each unit is notified cert available.
         if conversation.get_remote('{0}.server.cert'.format(name)):
             conversation.set_state('{relation_name}.server.cert.available')
-        if conversation.get_remote('processed_requests'):
+        if conversation.get_remote('{0}.processed_requests'.format(name)):
             conversation.set_state('{relation_name}.batch.cert.available')
 
     @hook('{provides:tls-certificates}-relation-{broken,departed}')
@@ -104,7 +104,7 @@ class TlsRequires(RelationBase):
 
     def get_batch_requests(self):
         # The scope is the unit name, replace the slash with underscore.
-        name = scope.replace('/', '_')
+        name = hookenv.local_unit().replace('/', '_')
         conversation = self.conversation()
         reqs = conversation.get_remote('{}.processed_requests'.format(name))
         if reqs:

--- a/requires.py
+++ b/requires.py
@@ -103,8 +103,10 @@ class TlsRequires(RelationBase):
             json.dumps(cert_requests, sort_keys=True))
 
     def get_batch_requests(self):
+        # The scope is the unit name, replace the slash with underscore.
+        name = scope.replace('/', '_')
         conversation = self.conversation()
-        reqs = conversation.get_remote('processed_requests')
+        reqs = conversation.get_remote('{}.processed_requests'.format(name))
         if reqs:
             return json.loads(reqs)
         else:

--- a/requires.py
+++ b/requires.py
@@ -35,6 +35,8 @@ class TlsRequires(RelationBase):
         # Prefix the key with the name so each unit is notified cert available.
         if conversation.get_remote('{0}.server.cert'.format(name)):
             conversation.set_state('{relation_name}.server.cert.available')
+        if conversation.get_remote('processed_requests'):
+            conversation.set_state('{relation_name}.batch.cert.available')
 
     @hook('{provides:tls-certificates}-relation-{broken,departed}')
     def broken_or_departed(self):
@@ -48,6 +50,13 @@ class TlsRequires(RelationBase):
         conversation = self.conversation()
         # Find the certificate authority by key, and return the value.
         return conversation.get_remote('ca')
+
+    def get_chain(self):
+        '''Return the chain from the relation object.'''
+        # Get the global scoped conversation.
+        conversation = self.conversation()
+        # Find the chain
+        return conversation.get_remote('chain')
 
     def get_client_cert(self):
         '''Return the client certificate and key from the relation object.'''
@@ -92,3 +101,11 @@ class TlsRequires(RelationBase):
         conversation.set_remote(
             'cert_requests',
             json.dumps(cert_requests, sort_keys=True))
+
+    def get_batch_requests(self):
+        conversation = self.conversation()
+        reqs = conversation.get_remote('processed_requests')
+        if reqs:
+            return json.loads(reqs)
+        else:
+            return {}

--- a/requires.py
+++ b/requires.py
@@ -74,3 +74,21 @@ class TlsRequires(RelationBase):
         conversation.set_remote('common_name', cn)
         conversation.set_remote('sans', json.dumps(sans))
         conversation.set_remote('certificate_name', cert_name)
+
+    def add_request_server_cert(self, cn, sans):
+        conversation = self.conversation()
+        cert_requests = conversation.get_local('cert_requests')
+
+        if cert_requests:
+            cert_requests[cn] = {'sans': sans}
+        else:
+            cert_requests = {
+                cn: {'sans': sans}}
+        conversation.set_local('cert_requests', cert_requests)
+
+    def request_server_certs(self):
+        conversation = self.conversation()
+        cert_requests = conversation.get_local('cert_requests')
+        conversation.set_remote(
+            'cert_requests',
+            json.dumps(cert_requests, sort_keys=True))


### PR DESCRIPTION
Allow a client to request multiple certificates from the certificate provider and, optionally, allow a chain to be provided to the clients. A server can build up multiple requests by using the add_request_server_cert method and then calling request_server_certs when ready eg

@when('certificates.available')
def request_cert(tls):
    tls.add_request_server_cert('admin.keystone.openstack.local', ['10.0.0.23', 'alt.openstack.local])
    tls.add_request_server_cert('internal.keystone.openstack.local', [])
    tls.request_server_certs()

Under the covers a new key 'cert_requests' is used on the relation. This is set to a json dump of a dictionary representing the requests.

The certificates provider then uses add_server_cert to build up the response before sending the response with set_server_multicerts eg

tls.add_server_cert(unit_name, 'admin.keystone.openstack.local', 'CERT1', 'KEY1')
tls.add_server_cert(unit_name, ''internal.keystone.openstack.local', 'CERT2', 'KEY2')
tls.set_server_multicerts(unit_name)