### PR TITLE
Fix cross-model relations

### DIFF
--- a/docs/requires.md
+++ b/docs/requires.md
@@ -15,7 +15,7 @@ The following flags may be set:
     Whenever the relation is joined.
 
   * `{endpoint_name}.ca.available`
-    When the root CA information is available via the [root_ca][] and
+    When the root CA information is available via the [root_ca_cert][] and
     [root_ca_chain][] properties.
 
   * `{endpoint_name}.ca.changed`
@@ -57,7 +57,7 @@ The following flags have been deprecated:
 
 [Certificate]: common.md#tls_certificates_common.Certificate
 [CertificateRequest]: common.md#tls_certificates_common.CertificateRequest
-[root_ca]: requires.md#requires.TlsRequires.root_ca
+[root_ca_cert]: requires.md#requires.TlsRequires.root_ca_cert
 [root_ca_chain]: requires.md#requires.TlsRequires.root_ca_chain
 [request_server_cert]: requires.md#requires.TlsRequires.request_server_cert
 [request_client_cert]: requires.md#requires.TlsRequires.request_client_cert
@@ -103,7 +103,7 @@ TlsRequires.get_ca(self)
 
 Return the root CA certificate.
 
-Same as [root_ca][].
+Same as [root_ca_cert][].
 
 <h2 id="requires.TlsRequires.get_chain">get_chain</h2>
 

--- a/provides.py
+++ b/provides.py
@@ -1,3 +1,8 @@
+if not __package__:
+    # fix relative imports when building docs
+    import sys
+    __package__ = sys.modules[''].__name__
+
 from charms.reactive import Endpoint
 from charms.reactive import when, when_not
 from charms.reactive import set_flag, clear_flag, toggle_flag

--- a/requires.py
+++ b/requires.py
@@ -1,3 +1,8 @@
+if not __package__:
+    # fix relative imports when building docs
+    import sys
+    __package__ = sys.modules[''].__name__
+
 import uuid
 
 from charmhelpers.core import hookenv
@@ -73,6 +78,7 @@ class TlsRequires(Endpoint):
 
     @when('endpoint.{endpoint_name}.joined')
     def joined(self):
+        self.relations[0].to_publish_raw['unit_name'] = self._unit_name
         prefix = self.expand_name('{endpoint_name}.')
         ca_available = self.root_ca_cert
         ca_changed = ca_available and data_changed(prefix + 'ca',
@@ -116,6 +122,10 @@ class TlsRequires(Endpoint):
         clear_flag(prefix + 'server.cert.available')
         clear_flag(prefix + 'client.cert.available')
         clear_flag(prefix + 'batch.cert.available')
+
+    @property
+    def _unit_name(self):
+        return hookenv.local_unit().replace('/', '_')
 
     @property
     def root_ca_cert(self):
@@ -178,15 +188,14 @@ class TlsRequires(Endpoint):
         List of [Certificate][] instances for all available server certs.
         """
         certs = []
-        name = hookenv.local_unit().replace('/', '_')
         raw_data = self.all_joined_units.received_raw
         json_data = self.all_joined_units.received
 
         # for backwards compatibility, the first cert goes in its own fields
         if self.relations:
             common_name = self.relations[0].to_publish_raw['common_name']
-            cert = raw_data['{}.server.cert'.format(name)]
-            key = raw_data['{}.server.key'.format(name)]
+            cert = raw_data['{}.server.cert'.format(self._unit_name)]
+            key = raw_data['{}.server.key'.format(self._unit_name)]
             if cert and key:
                 certs.append(Certificate('server',
                                          common_name,
@@ -194,7 +203,8 @@ class TlsRequires(Endpoint):
                                          key))
 
         # subsequent requests go in the collection
-        certs_data = json_data['{}.processed_requests'.format(name)] or {}
+        field = '{}.processed_requests'.format(self._unit_name)
+        certs_data = json_data[field] or {}
         certs.extend(Certificate('server',
                                  common_name,
                                  cert['cert'],
@@ -222,8 +232,7 @@ class TlsRequires(Endpoint):
         """
         List of [Certificate][] instances for all available client certs.
         """
-        name = hookenv.local_unit().replace('/', '_')
-        field = '{}.processed_client_requests'.format(name)
+        field = '{}.processed_client_requests'.format(self._unit_name)
         certs_data = self.all_joined_units.received[field] or {}
         return [Certificate('client',
                             common_name,

--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -19,7 +19,10 @@ class CertificateRequest(dict):
 
     @property
     def unit_name(self):
-        return self._unit.unit_name
+        unit_name = self._unit.received_raw['unit_name']
+        if not unit_name:
+            unit_name = self._unit.unit_name.replace('/', '_')
+        return unit_name
 
     @property
     def cert_type(self):
@@ -42,22 +45,19 @@ class CertificateRequest(dict):
 
     @property
     def _publish_key(self):
-        unit_name = self._unit.unit_name.replace('/', '_')
         if self.cert_type == 'server':
-            return '{}.processed_requests'.format(unit_name)
+            return '{}.processed_requests'.format(self.unit_name)
         elif self.cert_type == 'client':
-            return '{}.processed_client_requests'.format(unit_name)
+            return '{}.processed_client_requests'.format(self.unit_name)
         raise ValueError('Unknown cert_type: {}'.format(self.cert_type))
 
     @property
     def _server_cert_key(self):
-        unit_name = self._unit.unit_name.replace('/', '_')
-        return '{}.server.cert'.format(unit_name)
+        return '{}.server.cert'.format(self.unit_name)
 
     @property
     def _server_key_key(self):
-        unit_name = self._unit.unit_name.replace('/', '_')
-        return '{}.server.key'.format(unit_name)
+        return '{}.server.key'.format(self.unit_name)
 
     @property
     def _is_top_level_server_cert(self):

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,6 @@ deps=
 
 [testenv:docs]
 commands=python make_docs
+
+[flake8]
+ignore=E402


### PR DESCRIPTION
With cross-model relations (CMR), the "unit name" visible on the offering side of the relation is a UUID which doesn't match with the unit's own view of its unit name.  Thus, the unit cannot find the responses to its cert requests, as they are keyed by the UUID rather than the unit name.  By explicitly publishing the unit name over the relation, it ensures that the provider and requirer will use the same key.

We use the unit name rather than a UUID or nonce to ensure that non-CMR deployments are not broken upon upgrade.

Fixes #14 and [lp:1813605](https://bugs.launchpad.net/vault-charm/+bug/1813605)