### PR TITLE
Fix SANs order change causing "new" cert request

### DIFF
--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -87,7 +87,7 @@ class CertificateRequest(dict):
     @property
     def is_handled(self):
         has_cert = self.cert is not None
-        same_sans = not is_data_changed(self._key, self.sans)
+        same_sans = not is_data_changed(self._key, sorted(set(self.sans)))
         return has_cert and same_sans
 
     def set_cert(self, cert, key):


### PR DESCRIPTION
If the order of entries in the SANs list changes, it shouldn't be considered a new request.  Same for duplicate entries being added or removed.

Fixes [lp:1826625](https://bugs.launchpad.net/charm-easyrsa/+bug/1826625)
See also: https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/18
See also: https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/9