### PR TITLE
Revert "Fix SANs order change causing "new" cert request"

### DIFF
--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -87,7 +87,7 @@ class CertificateRequest(dict):
     @property
     def is_handled(self):
         has_cert = self.cert is not None
-        same_sans = not is_data_changed(self._key, sorted(set(self.sans)))
+        same_sans = not is_data_changed(self._key, self.sans)
         return has_cert and same_sans
 
     def set_cert(self, cert, key):


### PR DESCRIPTION
Reverts juju-solutions/interface-tls-certificates#17

I saw failures in easyrsa edge:
```
unit-easyrsa-0: 12:23:01 ERROR unit.easyrsa/0.juju-log client:7: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-easyrsa-0/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 73, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-easyrsa-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-easyrsa-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-easyrsa-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-easyrsa-0/charm/reactive/easyrsa.py", line 244, in create_server_cert
    for request in tls.new_server_requests:
  File "/var/lib/juju/agents/unit-easyrsa-0/charm/hooks/relations/tls-certificates/provides.py", line 227, in new_server_requests
    return [req for req in self.new_requests if req.cert_type == 'server']
  File "/var/lib/juju/agents/unit-easyrsa-0/charm/hooks/relations/tls-certificates/provides.py", line 205, in new_requests
    return [req for req in self.all_requests if not req.is_handled]
  File "/var/lib/juju/agents/unit-easyrsa-0/charm/hooks/relations/tls-certificates/provides.py", line 205, in <listcomp>
    return [req for req in self.all_requests if not req.is_handled]
  File "/var/lib/juju/agents/unit-easyrsa-0/charm/hooks/relations/tls-certificates/tls_certificates_common.py", line 90, in is_handled
    same_sans = not is_data_changed(self._key, sorted(set(self.sans)))
TypeError: 'NoneType' object is not iterable
```

We can reintroduce this later if desired, but I didn't want to spend too much time looking into it, so for now I suggest we just revert it.