### PR TITLE
Reintroduce fix for SANs order change causing "new" cert request

### DIFF
--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -87,7 +87,8 @@ class CertificateRequest(dict):
     @property
     def is_handled(self):
         has_cert = self.cert is not None
-        same_sans = not is_data_changed(self._key, self.sans)
+        same_sans = not is_data_changed(self._key,
+                                        sorted(set(self.sans or [])))
         return has_cert and same_sans
 
     def set_cert(self, cert, key):


### PR DESCRIPTION
This fixes the issue seen in #18 which prompted the revert of #17.

Fixes [lp:1826625](https://bugs.launchpad.net/charm-easyrsa/+bug/1826625)