### PR TITLE
make data_changed and is_data_changed handle None the same way

### DIFF
--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -114,7 +114,7 @@ class CertificateRequest(dict):
         if not rel.endpoint.new_requests:
             clear_flag(rel.endpoint.expand_name('{endpoint_name}.'
                                                 'certs.requested'))
-        data_changed(self._key, self.sans)
+        data_changed(self._key, sorted(set(self.sans or [])))
 
 
 class Certificate(dict):


### PR DESCRIPTION
In #19, we check if a sorted list has changed with is_data_changed. Make sure we sort the actual data_changed in the same way so the check is accurate.

If we don't do this, we may set a key as `None` in `data_changed` but then check that key against `[]` in `is_data_changed`. That makes `is_handled` always return false, which brings back our old friend:

https://bugs.launchpad.net/charm-easyrsa/+bug/1826625