### PR TITLE
Avoid generating new UUID for cert name if not needed

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -267,7 +267,10 @@ class TlsRequires(Endpoint):
             # for backwards compatibility, first request goes in its own fields
             to_publish_raw['common_name'] = cn
             to_publish_json['sans'] = sans or []
-            to_publish_raw['certificate_name'] = cert_name or str(uuid.uuid4())
+            cert_name = to_publish_raw.get('certificate_name') or cert_name
+            if cert_name is None:
+                cert_name = str(uuid.uuid4())
+            to_publish_raw['certificate_name'] = cert_name
         else:
             # subsequent requests go in the collection
             requests = to_publish_json.get('cert_requests', {})


### PR DESCRIPTION
If `request_server_cert` is called more than once for a CN without providing a value for the deprecated `cert_name` field, a new UUID will be generated every time, leading to relation changed hooks being triggered even if none of the other data has changed.

Fixes [lp:1850197](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1850197)