### PR TITLE
Add support for application certs

### DIFF
--- a/docs/common.md
+++ b/docs/common.md
@@ -4,6 +4,13 @@
 CertificateRequest(self, unit, cert_type, cert_name, common_name, sans)
 ```
 
+<h2 id="tls_certificates_common.CertificateRequest.application_name">application_name</h2>
+
+Name of the application which the request came from.
+
+:returns: Name of application
+:rtype: str
+
 <h2 id="tls_certificates_common.CertificateRequest.cert">cert</h2>
 
 
@@ -13,6 +20,23 @@ The cert published for this request, if any.
 
 
 Type of certificate, 'server' or 'client', being requested.
+
+<h2 id="tls_certificates_common.CertificateRequest.resolve_unit_name">resolve_unit_name</h2>
+
+```python
+CertificateRequest.resolve_unit_name(unit)
+```
+Return name of unit associated with this request.
+
+unit_name should be provided in the relation data to ensure
+compatability with cross-model relations. If the unit name
+is absent then fall back to unit_name attribute of the
+unit associated with this request.
+
+:param unit: Unit to extract name from
+:type unit: charms.reactive.endpoints.RelatedUnit
+:returns: Name of unit
+:rtype: str
 
 <h1 id="tls_certificates_common.Certificate">Certificate</h1>
 

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -60,6 +60,26 @@ def regen_all_certs():
         request.set_cert(cert, key)
 ```
 
+<h2 id="provides.TlsProvides.new_application_requests">new_application_requests</h2>
+
+
+Filtered view of [new_requests][] that only includes application cert
+requests.
+
+Each will be an instance of [ApplicationCertificateRequest][].
+
+Example usage:
+
+```python
+@when('tls.application.certs.requested')
+def gen_application_certs():
+    tls = endpoint_from_flag('tls.application.certs.requested')
+    for request in tls.new_application_requests:
+        cert, key = generate_application_cert(request.common_name,
+                                              request.sans)
+        request.set_cert(cert, key)
+```
+
 <h2 id="provides.TlsProvides.new_client_requests">new_client_requests</h2>
 
 
@@ -127,7 +147,7 @@ def gen_server_certs():
 <h2 id="provides.TlsProvides.set_ca">set_ca</h2>
 
 ```python
-TlsProvides.set_ca(self, certificate_authority)
+TlsProvides.set_ca(certificate_authority)
 ```
 
 Publish the CA to all related applications.
@@ -135,7 +155,7 @@ Publish the CA to all related applications.
 <h2 id="provides.TlsProvides.set_chain">set_chain</h2>
 
 ```python
-TlsProvides.set_chain(self, chain)
+TlsProvides.set_chain(chain)
 ```
 
 Publish the chain of trust to all related applications.
@@ -143,7 +163,7 @@ Publish the chain of trust to all related applications.
 <h2 id="provides.TlsProvides.set_client_cert">set_client_cert</h2>
 
 ```python
-TlsProvides.set_client_cert(self, cert, key)
+TlsProvides.set_client_cert(cert, key)
 ```
 
 Deprecated.  This is only for backwards compatibility.
@@ -153,7 +173,7 @@ Publish a globally shared client cert and key.
 <h2 id="provides.TlsProvides.set_server_cert">set_server_cert</h2>
 
 ```python
-TlsProvides.set_server_cert(self, scope, cert, key)
+TlsProvides.set_server_cert(scope, cert, key)
 ```
 
 Deprecated.  Use one of the [new_requests][] collections and
@@ -164,7 +184,7 @@ Set the server cert and key for the request identified by `scope`.
 <h2 id="provides.TlsProvides.set_server_multicerts">set_server_multicerts</h2>
 
 ```python
-TlsProvides.set_server_multicerts(self, scope)
+TlsProvides.set_server_multicerts(scope)
 ```
 
 Deprecated.  Done automatically.
@@ -172,7 +192,7 @@ Deprecated.  Done automatically.
 <h2 id="provides.TlsProvides.add_server_cert">add_server_cert</h2>
 
 ```python
-TlsProvides.add_server_cert(self, scope, cn, cert, key)
+TlsProvides.add_server_cert(scope, cn, cert, key)
 ```
 
 Deprecated.  Use `request.set_cert()` instead.
@@ -180,7 +200,7 @@ Deprecated.  Use `request.set_cert()` instead.
 <h2 id="provides.TlsProvides.get_server_requests">get_server_requests</h2>
 
 ```python
-TlsProvides.get_server_requests(self)
+TlsProvides.get_server_requests()
 ```
 
 Deprecated.  Use the [new_requests][] or [server_requests][]

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -65,6 +65,11 @@ The following flags have been deprecated:
 [server_certs_map]: requires.md#requires.TlsRequires.server_certs_map
 [client_certs]: requires.md#requires.TlsRequires.server_certs
 
+<h2 id="requires.TlsRequires.application_certs">application_certs</h2>
+
+
+List of [Certificate][] instances for all available application certs.
+
 <h2 id="requires.TlsRequires.client_certs">client_certs</h2>
 
 
@@ -98,7 +103,7 @@ Mapping of server [Certificate][] instances by their `common_name`.
 <h2 id="requires.TlsRequires.get_ca">get_ca</h2>
 
 ```python
-TlsRequires.get_ca(self)
+TlsRequires.get_ca()
 ```
 
 Return the root CA certificate.
@@ -108,7 +113,7 @@ Same as [root_ca_cert][].
 <h2 id="requires.TlsRequires.get_chain">get_chain</h2>
 
 ```python
-TlsRequires.get_chain(self)
+TlsRequires.get_chain()
 ```
 
 Return the chain of trust for the root CA.
@@ -118,7 +123,7 @@ Same as [root_ca_chain][].
 <h2 id="requires.TlsRequires.get_client_cert">get_client_cert</h2>
 
 ```python
-TlsRequires.get_client_cert(self)
+TlsRequires.get_client_cert()
 ```
 
 Deprecated.  Use [request_client_cert][] and the [client_certs][]
@@ -129,7 +134,7 @@ Return a globally shared client certificate and key.
 <h2 id="requires.TlsRequires.get_server_cert">get_server_cert</h2>
 
 ```python
-TlsRequires.get_server_cert(self)
+TlsRequires.get_server_cert()
 ```
 
 Deprecated.  Use the [server_certs][] collection instead.
@@ -139,7 +144,7 @@ Return the cert and key of the first server certificate requested.
 <h2 id="requires.TlsRequires.get_batch_requests">get_batch_requests</h2>
 
 ```python
-TlsRequires.get_batch_requests(self)
+TlsRequires.get_batch_requests()
 ```
 
 Deprecated.  Use [server_certs_map][] instead.
@@ -149,7 +154,7 @@ Mapping of server [Certificate][] instances by their `common_name`.
 <h2 id="requires.TlsRequires.request_server_cert">request_server_cert</h2>
 
 ```python
-TlsRequires.request_server_cert(self, cn, sans=None, cert_name=None)
+TlsRequires.request_server_cert(cn, sans=None, cert_name=None)
 ```
 
 Request a server certificate and key be generated for the given
@@ -164,7 +169,7 @@ again with the same common name, it will be ignored.
 <h2 id="requires.TlsRequires.add_request_server_cert">add_request_server_cert</h2>
 
 ```python
-TlsRequires.add_request_server_cert(self, cn, sans)
+TlsRequires.add_request_server_cert(cn, sans)
 ```
 
 Deprecated.  Use [request_server_cert][] instead.
@@ -172,7 +177,7 @@ Deprecated.  Use [request_server_cert][] instead.
 <h2 id="requires.TlsRequires.request_server_certs">request_server_certs</h2>
 
 ```python
-TlsRequires.request_server_certs(self)
+TlsRequires.request_server_certs()
 ```
 
 Deprecated.  Just use [request_server_cert][]; this does nothing.
@@ -180,7 +185,7 @@ Deprecated.  Just use [request_server_cert][]; this does nothing.
 <h2 id="requires.TlsRequires.request_client_cert">request_client_cert</h2>
 
 ```python
-TlsRequires.request_client_cert(self, cn, sans)
+TlsRequires.request_client_cert(cn, sans)
 ```
 
 Request a client certificate and key be generated for the given
@@ -189,4 +194,14 @@ common name (`cn`) and list of alternative names (`sans`).
 This can be called multiple times to request more than one client
 certificate, although the common names must be unique.  If called
 again with the same common name, it will be ignored.
+
+<h2 id="requires.TlsRequires.request_application_cert">request_application_cert</h2>
+
+```python
+TlsRequires.request_application_cert(cn, sans)
+```
+
+Request an application certificate and key be generated for the given
+common name (`cn`) and list of alternative names (`sans` ) of this
+unit and all peer units. All units will share a single certificates.
 

--- a/provides.py
+++ b/provides.py
@@ -285,6 +285,9 @@ class TlsProvides(Endpoint):
                                                       request.sans)
                 request.set_cert(cert, key)
         ```
+
+        :returns: List of certificate requests.
+        :rtype: [CertificateRequest, ]
         """
         return [req for req in self.new_requests
                 if req.cert_type == 'application']

--- a/provides.py
+++ b/provides.py
@@ -7,7 +7,10 @@ from charms.reactive import Endpoint
 from charms.reactive import when, when_not
 from charms.reactive import set_flag, clear_flag, toggle_flag
 
-from .tls_certificates_common import CertificateRequest
+from .tls_certificates_common import (
+    ApplicationCertificateRequest,
+    CertificateRequest
+)
 
 
 class TlsProvides(Endpoint):
@@ -48,6 +51,9 @@ class TlsProvides(Endpoint):
                     self.new_server_requests)
         toggle_flag(self.expand_name('{endpoint_name}.client.certs.requested'),
                     self.new_client_requests)
+        toggle_flag(
+            self.expand_name('{endpoint_name}.application.certs.requested'),
+            self.new_application_requests)
         # For backwards compatibility, set the old "cert" flags as well
         toggle_flag(self.expand_name('{endpoint_name}.server.cert.requested'),
                     self.new_server_requests)
@@ -60,6 +66,8 @@ class TlsProvides(Endpoint):
         clear_flag(self.expand_name('{endpoint_name}.certs.requested'))
         clear_flag(self.expand_name('{endpoint_name}.server.certs.requested'))
         clear_flag(self.expand_name('{endpoint_name}.client.certs.requested'))
+        clear_flag(
+            self.expand_name('{endpoint_name}.application.certs.requested'))
 
     def set_ca(self, certificate_authority):
         """
@@ -176,6 +184,16 @@ class TlsProvides(Endpoint):
                     common_name,
                     req['sans'],
                 ))
+            # handle application cert requests
+            reqs = unit.received['application_cert_requests'] or {}
+            for common_name, req in reqs.items():
+                requests.append(ApplicationCertificateRequest(
+                    unit,
+                    'application',
+                    common_name,
+                    common_name,
+                    req['sans']
+                ))
         return requests
 
     @property
@@ -247,6 +265,29 @@ class TlsProvides(Endpoint):
         ```
         """
         return [req for req in self.new_requests if req.cert_type == 'client']
+
+    @property
+    def new_application_requests(self):
+        """
+        Filtered view of [new_requests][] that only includes application cert
+        requests.
+
+        Each will be an instance of [ApplicationCertificateRequest][].
+
+        Example usage:
+
+        ```python
+        @when('tls.application.certs.requested')
+        def gen_application_certs():
+            tls = endpoint_from_flag('tls.application.certs.requested')
+            for request in tls.new_application_requests:
+                cert, key = generate_application_cert(request.common_name,
+                                                      request.sans)
+                request.set_cert(cert, key)
+        ```
+        """
+        return [req for req in self.new_requests
+                if req.cert_type == 'application']
 
     @property
     def all_published_certs(self):

--- a/requires.py
+++ b/requires.py
@@ -213,6 +213,25 @@ class TlsRequires(Endpoint):
         return certs
 
     @property
+    def application_certs(self):
+        """
+        List of [Certificate][] instances for all available application certs.
+        """
+        certs = []
+        json_data = self.all_joined_units.received
+        field = '{}.processed_application_requests'.format(self._unit_name)
+        certs_data = json_data[field] or {}
+        app_cert_data = certs_data.get('app_data')
+        if app_cert_data:
+            certs = [Certificate(
+                'server',
+                'app_data',
+                app_cert_data['cert'],
+                app_cert_data['key'])]
+        return certs
+
+
+    @property
     def server_certs_map(self):
         """
         Mapping of server [Certificate][] instances by their `common_name`.
@@ -305,3 +324,17 @@ class TlsRequires(Endpoint):
         requests = to_publish_json.get('client_cert_requests', {})
         requests[cn] = {'sans': sans}
         to_publish_json['client_cert_requests'] = requests
+
+    def request_application_cert(self, cn, sans):
+        """
+        Request an application certificate and key be generated for the given
+        common name (`cn`) and list of alternative names (`sans` ) of this
+        unit and all peer units. All units will share a single certificates.
+        """
+        if not self.relations:
+            return
+        # assume we'll only be connected to one provider
+        to_publish_json = self.relations[0].to_publish
+        requests = to_publish_json.get('application_cert_requests', {})
+        requests[cn] = {'sans': sans}
+        to_publish_json['application_cert_requests'] = requests

--- a/requires.py
+++ b/requires.py
@@ -215,7 +215,10 @@ class TlsRequires(Endpoint):
     @property
     def application_certs(self):
         """
-        List of [Certificate][] instances for all available application certs.
+        List containg the application Certificate cert.
+
+        :returns: A list containing one certificate
+        :rtype: [Certificate()]
         """
         certs = []
         json_data = self.all_joined_units.received
@@ -229,7 +232,6 @@ class TlsRequires(Endpoint):
                 app_cert_data['cert'],
                 app_cert_data['key'])]
         return certs
-
 
     @property
     def server_certs_map(self):

--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -37,6 +37,11 @@ class CertificateRequest(dict):
 
     @property
     def unit_name(self):
+        """Name of this unit.
+
+        :returns: Name of unit
+        :rtype: str
+        """
         return self.resolve_unit_name(unit=self._unit).replace('/', '_')
 
     @property
@@ -154,12 +159,20 @@ class ApplicationCertificateRequest(CertificateRequest):
 
     @property
     def _key(self):
+        """Key to identify this cert.
+
+        :returns: cert key
+        :rtype: str
+        """
         return '{}.{}'.format(self._unit.relation.relation_id, 'app_cert')
 
     @property
     def cert(self):
         """
         The cert published for this request, if any.
+
+        :returns: Certificate
+        :rtype: Certificate or None
         """
         cert, key = None, None
         tp = self._unit.relation.to_publish
@@ -173,6 +186,11 @@ class ApplicationCertificateRequest(CertificateRequest):
 
     @property
     def is_handled(self):
+        """Whether the certificate has been handled.
+
+        :returns: If the cert has been handled
+        :rtype: bool
+        """
         has_cert = self.cert is not None
         same_sans = not is_data_changed(self._key,
                                         sorted(set(self.sans or [])))
@@ -198,6 +216,11 @@ class ApplicationCertificateRequest(CertificateRequest):
 
     @property
     def _request_key(self):
+        """Key used to request cert
+
+        :returns: Key used to request cert
+        :rtype: str
+        """
         return 'application_cert_requests'
 
     def derive_publish_key(self, unit=None):
@@ -215,6 +238,11 @@ class ApplicationCertificateRequest(CertificateRequest):
 
     @property
     def _publish_key(self):
+        """Key used to publish cert
+
+        :returns: Key used to publish cert
+        :rtype: str
+        """
         return self.derive_publish_key(unit=self._unit)
 
     def set_cert(self, cert, key):

--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -17,12 +17,36 @@ class CertificateRequest(dict):
                          self.unit_name,
                          self.common_name))
 
+    def resolve_unit_name(self, unit):
+        """Return name of unit associated with this request.
+
+        unit_name should be provided in the relation data to ensure
+        compatability with cross-model relations. If the unit name
+        is absent then fall back to unit_name attribute of the
+        unit associated with this request.
+
+        :param unit: Unit to extract name from
+        :type unit: charms.reactive.endpoints.RelatedUnit
+        :returns: Name of unit
+        :rtype: str
+        """
+        unit_name = unit.received_raw['unit_name']
+        if not unit_name:
+            unit_name = unit.unit_name
+        return unit_name
+
     @property
     def unit_name(self):
-        unit_name = self._unit.received_raw['unit_name']
-        if not unit_name:
-            unit_name = self._unit.unit_name.replace('/', '_')
-        return unit_name
+        return self.resolve_unit_name(unit=self._unit).replace('/', '_')
+
+    @property
+    def application_name(self):
+        """Name of the application which the request came from.
+
+        :returns: Name of application
+        :rtype: str
+        """
+        return self.resolve_unit_name(unit=self._unit).split('/')[0]
 
     @property
     def cert_type(self):
@@ -114,6 +138,86 @@ class CertificateRequest(dict):
         if not rel.endpoint.new_requests:
             clear_flag(rel.endpoint.expand_name('{endpoint_name}.'
                                                 'certs.requested'))
+        data_changed(self._key, sorted(set(self.sans or [])))
+
+
+class ApplicationCertificateRequest(CertificateRequest):
+    """
+    A request for an application consistent certificate.
+
+    This is a request for a certificate that works for all units of an
+    application. All sans and cns are added together to produce one
+    certificate and the same certificate and key are sent to all the
+    units of an application. Only one ApplicationCertificateRequest
+    is needed per application.
+    """
+
+    @property
+    def _key(self):
+        return '.'.join((self._unit.relation.relation_id,
+                         self.common_name))
+
+    @property
+    def sans(self):
+        """Generate a list of all sans from all units of application
+
+        Examine all units of the application and compile a list of
+        all sans. CNs are treated as addition san entries.
+
+        :returns: List of sans
+        :rtype: List[str]
+        """
+        _sans = []
+        for unit in self._unit.relation.units:
+            reqs = unit.received['application_cert_requests'] or {}
+            for cn, req in reqs.items():
+                _sans.append(cn)
+                _sans.extend(req['sans'])
+        return list(set(_sans))
+
+    @property
+    def _request_key(self):
+        return 'application_cert_requests'
+
+    def derive_publish_key(self, unit=None):
+        """Derive the application cert publish key for a unit.
+
+        :param unit: Unit to extract name from
+        :type unit: charms.reactive.endpoints.RelatedUnit
+        :returns: publish key
+        :rtype: str
+        """
+        if not unit:
+            unit = self._unit
+        unit_name = self.resolve_unit_name(unit).replace('/', '_')
+        return '{}.processed_application_requests'.format(unit_name)
+
+    @property
+    def _publish_key(self):
+        return self.resolve_unit_name(unit=self._unit).replace('/', '_')
+
+    def set_cert(self, cert, key):
+        """Send the cert and key to all units of the application
+
+        :param cert: TLS Certificate
+        :type cert: str
+        :param key: TLS Private Key
+        :type cert: str
+        """
+        rel = self._unit.relation
+        for unit in self._unit.relation.units:
+            pub_key = self.derive_publish_key(unit=unit)
+            data = rel.to_publish.get(
+                pub_key,
+                {})
+            data['app_data'] = {
+                'cert': cert,
+                'key': key,
+            }
+            rel.to_publish[pub_key] = data
+        if not rel.endpoint.new_application_requests:
+            clear_flag(rel.endpoint.expand_name(
+                '{endpoint_name}.application.certs.requested'))
         data_changed(self._key, sorted(set(self.sans or [])))
 
 


### PR DESCRIPTION
The idea of an application cert is that it is identical on all
units. To generate one the interface collects all the published
sans and cns from the clients and generates one certificate
which is valid for all of them.