### PR TITLE
Add `connected` state to improve downstream charm messaging

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -22,6 +22,7 @@ class TlsRequires(Endpoint):
     The following flags may be set:
 
       * `{endpoint_name}.available`
+      * `{endpoint_name}.connected`
         Whenever the relation is joined.
 
       * `{endpoint_name}.ca.available`
@@ -92,6 +93,7 @@ class TlsRequires(Endpoint):
         certs_available = server_available or client_available
         certs_changed = server_changed or client_changed
 
+        set_flag(prefix + 'connected')
         set_flag(prefix + 'available')
         toggle_flag(prefix + 'ca.available', ca_available)
         toggle_flag(prefix + 'ca.changed', ca_changed)


### PR DESCRIPTION
Some charms have a distinction between something being alive in
the other end of a relation (`connected`) and the other end
actually being ready for prime time (`available`).

We don't have that distinction in the top level flags in this
interface but let's set both states to improve the messaging of
said charms.

Fixes #23