### PR TITLE
Fix error in request_client_cert, make sans optional

### DIFF
--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -101,7 +101,7 @@ class CertificatesRequires(Object):
         """Certificate instances by their `common_name`."""
         return {cert.common_name: cert for cert in self.client_certs}
 
-    def request_client_cert(self, cn, sans):
+    def request_client_cert(self, cn, sans=None):
         """Request Client certificate for charm.
 
         Request a client certificate and key be generated for the given
@@ -114,7 +114,7 @@ class CertificatesRequires(Object):
             return
         # assume we'll only be connected to one provider
         data = self.relation.data[self.model.unit]
-        requests = data.get("client_cert_requests", {})
+        requests = json.loads(data.get("client_cert_requests", "{}"))
         requests[cn] = {"sans": sans}
         data["client_cert_requests"] = json.dumps(requests)
 


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/venv/charms/reconciler.py", line 34, in reconcile
    result = self.reconcile_function(event)
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/./src/charm.py", line 36, in reconcile
    self.request_certificates()
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/./src/charm.py", line 75, in request_certificates
    self.certificates.request_client_cert("system:kube-apiserver", sans=None)
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/venv/ops/interface_tls_certificates/requires.py", line 118, in request_client_cert
    requests[cn] = {"sans": sans}
TypeError: 'str' object does not support item assignment
```

Also, made SANS optional for client certs since we generally do not use them for client certs anyway.