### PR TITLE
List no server ceritificates if the endpoint isn't connected

### DIFF
--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -150,8 +150,12 @@ class CertificatesRequires(Object):
         """
         List of [Certificate][] instances for all available server certs.
         """
+        if not self.relation:
+            log.warning(f"Relation {self.endpoint} is not yet available.")
+            return []
         common_name = self.relation.data[self.model.unit].get("common_name")
         if common_name is None or not self.is_ready:
+            log.warning(f"Relation {self.endpoint} is not yet available.")
             return []
 
         certs = []

--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -155,7 +155,7 @@ class CertificatesRequires(Object):
             return []
         common_name = self.relation.data[self.model.unit].get("common_name")
         if common_name is None or not self.is_ready:
-            log.warning(f"Relation {self.endpoint} is not yet available.")
+            log.warning(f"Relation {self.endpoint} has yet to set 'common_name'.")
             return []
 
         certs = []


### PR DESCRIPTION
Resolves [LP#2037111](https://launchpad.net/bugs/2037111)

Resolve issue where `server_certs` aren't available until the relation is up

```
2023-09-21 03:04:16 ERROR unit.kubeapi-load-balancer/0.juju-log server.go:316 'NoneType' object has no attribute 'data'
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-0/charm/venv/charms/reconciler.py", line 34, in reconcile
    result = self.reconcile_function(event)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-0/charm/./src/charm.py", line 329, in _reconcile
    self._write_certificates()
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-0/charm/./src/charm.py", line 381, in _write_certificates
    cert = self.certificates.server_certs_map.get(common_name)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-0/charm/venv/ops/interface_tls_certificates/requires.py", line 178, in server_certs_map
    return {cert.common_name: cert for cert in self.server_certs}
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-0/charm/venv/ops/interface_tls_certificates/requires.py", line 153, in server_certs
    common_name = self.relation.data[self.model.unit].get("common_name")
AttributeError: 'NoneType' object has no attribute 'data'
```