### PR TITLE
Add support for intermediate CA certificates

### DIFF
--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -200,7 +200,7 @@ class CertificatesRequires(Object):
         """Certificate instances by their `common_name`."""
         return {cert.common_name: cert for cert in self.intermediate_certs}
 
-    def request_intermediate_cert(self, cn, sans=None):
+    def request_intermediate_cert(self, cn: str, sans: Optional[List[str]] = None):
         """Request intermediate CA certificate for charm.
 
         Request an intermediate CA certificate and key be generated for the given
@@ -214,5 +214,5 @@ class CertificatesRequires(Object):
         # assume we'll only be connected to one provider
         data = self.relation.data[self.model.unit]
         requests = json.loads(data.get("intermediate_cert_requests", "{}"))
-        requests[cn] = {"sans": sans}
+        requests[cn] = {"sans": sans or []}
         data["intermediate_cert_requests"] = json.dumps(requests)

--- a/ops/tests/data/tls_certificate_data.yaml
+++ b/ops/tests/data/tls_certificate_data.yaml
@@ -250,3 +250,4 @@ test_1.server.key: |
   6XxaTFVYJUnHiWJ7gRB1Dfud
   -----END PRIVATE KEY-----
 private-address: 10.246.154.191
+test_0.processed_intermediate_requests: '{"127.0.0.1": {"cert": "FAKECERT", "key": "FAKEKEY"}}'

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -234,7 +234,11 @@ def test_request_intermediate_certs(certificates_requirer):
         relation.units = ["remote/0", certificates_requirer.model.unit]
         relation.data = defaultdict(defaultdict)
         certificates_requirer.request_intermediate_cert("127.0.0.1", ["1.1.1.1"])
+        certificates_requirer.request_intermediate_cert("nosans")
         request = relation.data[certificates_requirer.model.unit][
             "intermediate_cert_requests"
         ]
-        assert json.loads(request) == {"127.0.0.1": {"sans": ["1.1.1.1"]}}
+        assert json.loads(request) == {
+            "127.0.0.1": {"sans": ["1.1.1.1"]},
+            "nosans": {"sans": []},
+        }

--- a/requires.py
+++ b/requires.py
@@ -388,5 +388,5 @@ class TlsRequires(Endpoint):
         # assume we'll only be connected to one provider
         to_publish_json = self.relations[0].to_publish
         requests = to_publish_json.get("intermediate_cert_requests", {})
-        requests[cn] = {"sans": sans}
+        requests[cn] = {"sans": sans or []}
         to_publish_json["intermediate_cert_requests"] = requests

--- a/tls_certificates_common.py
+++ b/tls_certificates_common.py
@@ -80,6 +80,8 @@ class CertificateRequest(dict):
             return "{}.processed_requests".format(self.unit_name)
         elif self.cert_type == "client":
             return "{}.processed_client_requests".format(self.unit_name)
+        elif self.cert_type == "intermediate":
+            return "{}.processed_intermediate_requests".format(self.unit_name)
         raise ValueError("Unknown cert_type: {}".format(self.cert_type))
 
     @property


### PR DESCRIPTION
### Summary

Add support for requesting and providing intermediate CA certificates (adds new type `intermediate`)

### Changes

- Add `CertificateRequest.cert_type == 'intermediate'` support
- (reactive) Add `TlsRequires.request_intermediate_cert` and `TlsRequires.intermediate_certs`
- (ops) Add `CertificateRequires.request_intermediate_cert` and `CertificateRequires.intermediate_certs`
- (ops) Add unit tests for intermediate CA certificate requests

I have tried to follow the existing code and semantics as close as possible.