### PR TITLE
[LP#2039452] Address misspelling in the reactive based provider side

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -213,7 +213,7 @@ class TlsProvides(Endpoint):
                     )
                 )
             # handle intermediate CA cert requests
-            reqs = unit.receive["intermediate_cert_requests"] or {}
+            reqs = unit.received["intermediate_cert_requests"] or {}
             for common_name, req in reqs.items():
                 requests.append(
                     CertificateRequest(


### PR DESCRIPTION
FIXES: [LP#2039452](https://bugs.launchpad.net/charm-easyrsa/+bug/2039452)

Fixes a charm error condition when using easyrsa (or any provider side reactive version) of this charm

