### PR TITLE
Add ops support for vault as an intermediate CA

### DIFF
--- a/ops/ops/interface_tls_certificates/model.py
+++ b/ops/ops/interface_tls_certificates/model.py
@@ -11,6 +11,13 @@ class Certificate(BaseModel):
     cert: StrictStr
     key: StrictStr
 
+    def __init__(self, cert_type, common_name, cert, key, chain=None):
+        if chain:
+            cert += "\n" + chain
+        super().__init__(
+            cert_type=cert_type, common_name=common_name, cert=cert, key=key
+        )
+
 
 class Data(BaseModel, extra=Extra.allow):
     """Databag from the relation."""

--- a/ops/ops/interface_tls_certificates/model.py
+++ b/ops/ops/interface_tls_certificates/model.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, Extra, Field, StrictStr
 
 
@@ -14,5 +16,6 @@ class Data(BaseModel, extra=Extra.allow):
     """Databag from the relation."""
 
     ca: StrictStr = Field(alias="ca")
+    chain: Optional[StrictStr] = Field(None, alias="chain")
     client_cert: StrictStr = Field(alias="client.cert")
     client_key: StrictStr = Field(alias="client.key")

--- a/ops/ops/interface_tls_certificates/model.py
+++ b/ops/ops/interface_tls_certificates/model.py
@@ -16,6 +16,6 @@ class Data(BaseModel, extra=Extra.allow):
     """Databag from the relation."""
 
     ca: StrictStr = Field(alias="ca")
-    chain: Optional[StrictStr] = Field(None, alias="chain")
+    chain: Optional[StrictStr] = Field(default=None, alias="chain")
     client_cert: StrictStr = Field(alias="client.cert")
     client_key: StrictStr = Field(alias="client.key")

--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -104,8 +104,9 @@ class CertificatesRequires(Object):
             Certificate(
                 cert_type="client",
                 common_name=common_name,
-                cert=self.build_chain(cert_data.get("cert")),
+                cert=cert_data.get("cert"),
                 key=cert_data.get("key"),
+                chain=self.chain,
             )
             for common_name, cert_data in certs_data.items()
         ]
@@ -114,15 +115,6 @@ class CertificatesRequires(Object):
     def client_certs_map(self) -> Mapping[str, Certificate]:
         """Certificate instances by their `common_name`."""
         return {cert.common_name: cert for cert in self.client_certs}
-
-    def build_chain(self, cert) -> str:
-        """Build a certificate chain. This will include the provided
-        client/server cert, along with additional intermediate certificates
-        that are needed to connect the client/server cert back to the root CA.
-        """
-        if self.chain:
-            cert += "\n" + self.chain
-        return cert
 
     def request_client_cert(self, cn, sans=None):
         """Request Client certificate for charm.
@@ -189,8 +181,9 @@ class CertificatesRequires(Object):
                 Certificate(
                     cert_type="server",
                     common_name=common_name,
-                    cert=self.build_chain(cert),
+                    cert=cert,
                     key=key,
+                    chain=self.chain,
                 )
             )
 
@@ -201,8 +194,9 @@ class CertificatesRequires(Object):
             Certificate(
                 cert_type="server",
                 common_name=common_name,
-                cert=self.build_chain(cert_data.get("cert")),
+                cert=cert_data.get("cert"),
                 key=cert_data.get("key"),
+                chain=self.chain,
             )
             for common_name, cert_data in certs_data.items()
         ]


### PR DESCRIPTION
As seen in https://bugs.launchpad.net/bugs/2038347

This adds requires side support for the `chain` field to the ops library.

When vault is configured to act as an intermediate CA (see [here](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/app-certificate-management.html#third-party-intermediate-ca-certificate)), we end up with the following in relation data:
* `ca`: The root CA certificate
* `chain`: The intermediate CA certificate (vault), signed by the root CA
* client and server certificates, signed by the intermediate CA (vault)

Client and server processes need to be configured to provide a full certificate chain that ties back to the root CA. Without the intermediate CA certificate, the certificate chain is incomplete, and TLS verification fails.

To fix this, we append the intermediate CA certificate to all client and server certificates that come from the tls-certificates interface.