### PR TITLE
Fix error in request_server_cert by loading JSON string to dict

### DIFF
--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -159,7 +159,7 @@ class CertificatesRequires(Object):
             data["certificate_name"] = cert_name
         else:
             # subsequent requests go in the collection
-            requests = data.get("cert_requests", {})
+            requests = json.loads(data.get("cert_requests", "{}"))
             requests[cn] = {"sans": sans or []}
             data["cert_requests"] = json.dumps(requests)
 


### PR DESCRIPTION
This fixes a bug affecting multiple Kubernetes charms documented at https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/2058095. There was a similar fix for a different function in https://github.com/canonical/interface-tls-certificates/pull/28.