### PR TITLE
Don't record "not yet available" as an error

### DIFF
--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -70,10 +70,10 @@ class CertificatesRequires(Object):
         try:
             self._data
         except ValidationError as ve:
-            log.error(f"{self.endpoint} relation data not yet valid. ({ve}")
+            log.warning(f"{self.endpoint} relation data not yet valid. ({ve}")
             return False
         if self._data is None:
-            log.error(f"{self.endpoint} relation data not yet available.")
+            log.warning(f"{self.endpoint} relation data not yet available.")
             return False
         return True
 


### PR DESCRIPTION
It doesn't require any human intervention usually and it's just waiting for the other side of the relation.

Fixes: #36