### PR TITLE
databags with a cert_requets str, should load it as json

### DIFF
--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -159,7 +159,7 @@ class CertificatesRequires(Object):
             data["certificate_name"] = cert_name
         else:
             # subsequent requests go in the collection
-            requests = data.get("cert_requests", {})
+            requests = json.loads(data.get("cert_requests", "{}"))
             requests[cn] = {"sans": sans or []}
             data["cert_requests"] = json.dumps(requests)
 


### PR DESCRIPTION
### Overview
* Reading existing cert_requests  should consistently read the data it has sent

### Details
Each field in a relation databag is a string to string mapping
If the field is unset, we were getting a "dict" because it was empty
But when the field `cert_requests` is filled with a string, we should parse it as json